### PR TITLE
Added inline @import font support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -577,8 +577,7 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "autoprefixer": {
       "version": "6.7.7",
@@ -1820,6 +1819,24 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "css-color-names": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
@@ -2003,8 +2020,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -4624,8 +4640,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -8473,8 +8488,7 @@
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "dev": true
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -8557,6 +8571,11 @@
       "requires": {
         "symbol-observable": "1.0.1"
       }
+    },
+    "rxjs-compat": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.5.3.tgz",
+      "integrity": "sha512-BIJX2yovz3TBpjJoAZyls2QYuU6ZiCaZ+U96SmxQpuSP/qDUfiXPKOVLbThBB2WZijNHkdTTJXKRwvv5Y48H7g=="
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -9292,7 +9311,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-      "dev": true,
       "requires": {
         "atob": "^2.1.1",
         "decode-uri-component": "^0.2.0",
@@ -9313,8 +9331,7 @@
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -10205,8 +10222,7 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "dev": true
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
     "@angular/platform-browser-dynamic": "^4.0.0",
     "@angular/router": "^4.0.0",
     "core-js": "^2.4.1",
+    "css": "^2.2.4",
     "jquery": "^3.4.1",
-    "rxjs": "^5.1.0",
+    "rxjs": "^5.5.12",
+    "rxjs-compat": "^6.5.3",
     "save-svg-as-png": "^1.4.14",
     "svg.js": "^2.7.1",
     "zone.js": "^0.8.4"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
 import { SvgEditorComponent } from './svg-editor/svg-editor.component';
@@ -14,6 +15,7 @@ import { SvgEditorComponent } from './svg-editor/svg-editor.component';
   imports: [
     BrowserModule,
     FormsModule,
+    HttpClientModule,
     HttpModule
   ],
   providers: [],

--- a/src/app/svg-editor/svg-editor.component.ts
+++ b/src/app/svg-editor/svg-editor.component.ts
@@ -1,9 +1,14 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, Injectable } from '@angular/core';
 import * as $ from 'jquery';
 import { IMAGES } from "./image-data";
 import { FILLS } from "./image-data";
 import { ImageSection, ImageFile } from './image-file';
 import * as svg from 'save-svg-as-png';
+import css from 'css';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+
 declare const SVG:any;
 
 @Component({
@@ -11,6 +16,7 @@ declare const SVG:any;
   templateUrl: './svg-editor.component.html',
   styleUrls: ['./svg-editor.component.scss']
 })
+@Injectable()
 export class SvgEditorComponent implements OnInit {
   @Input() svgUrl;
 
@@ -18,7 +24,7 @@ export class SvgEditorComponent implements OnInit {
   fills: string[] = FILLS;
   svgDoc: any;
 
-  constructor() { }
+  constructor(private http: HttpClient) { }
 
   ngOnInit() {
     if(this.isKnownImage(this.svgUrl)){
@@ -81,7 +87,70 @@ export class SvgEditorComponent implements OnInit {
     }
   }
 
+  urlRegex: RegExp = /(?<=url\('?)(.*?)(?='?\))/g
+  formatRegex: RegExp = /(?<=format\(')(.*?)(?='\))/g
+
+  getRemoteSrc(fontSrcString: string){
+    return fontSrcString.match(this.urlRegex)[0];
+  }
+
+  getFormat(fontSrcString: string){
+    return fontSrcString.match(this.formatRegex)[0];
+  }
+
+  getText(fontObj: any){
+    var family = fontObj.declarations.filter(x => x.property == "font-family")[0].value;
+    var url = this.getRemoteSrc(fontObj.declarations.filter(x => x.property == "src")[0].value);
+    //var format = this.getFormat(fontObj.declarations.filter(x => x.property == "src")[0].value);
+    var style = fontObj.declarations.filter(x => x.property == "font-style")[0].value;
+    var weight = fontObj.declarations.filter(x => x.property == "font-weight")[0].value;
+    var display = fontObj.declarations.filter(x => x.property == "font-display")[0].value;
+    var unicode = fontObj.declarations.filter(x => x.property == "unicode-range")[0].value;
+      return `@font-face{\
+        font-family: ${family};\
+        src: url(${url});\
+        font-style: ${style};\
+        font-weight: ${weight};\
+        font-display: ${display};\
+        unicode-range: ${unicode};\
+      }`;
+  }
+
+  getImports(){
+    var urls = [];
+    var ctx = this;
+    $(this.svgDoc.node).find("style").each(function(i, o) {
+      var u = ctx.getRemoteSrc($(o).text().replace(/['"]/g,''));
+      urls.push(u);
+    });
+    return urls;
+  }
+
   saveToPng(){
-    svg.saveSvgAsPng(document.getElementById(this.svgDoc), "image.png", { scale: 0.5});
+    this.getImports();
+    var urls = this.getImports();
+    var fonts = [];
+    var reqs = [];
+    urls.forEach(u => {
+      reqs.push(this.http.get(u, {responseType: 'text'}));
+    });
+
+    Observable.forkJoin(reqs).subscribe({
+      next: results => {
+        results.forEach(r => {
+            var p = css.parse(r);
+            p.stylesheet.rules.filter(el => el.type == "font-face").forEach(element => {
+              fonts.push({
+                  text: this.getText(element),
+                  url: this.getRemoteSrc(element.declarations.filter(x => x.property == "src")[0].value),
+                  format: this.getFormat(element.declarations.filter(x => x.property == "src")[0].value)
+              });
+            });
+        });
+      },
+      complete: () => {
+        svg.saveSvgAsPng(document.getElementById(this.svgDoc), "image.png", { scale: 0.5, fonts: fonts });
+      }
+    });
   }
 }

--- a/src/assets/svg/LPGD_red.svg
+++ b/src/assets/svg/LPGD_red.svg
@@ -1,4 +1,11 @@
 <svg width="1920" height="1080" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+    <![CDATA[
+        @import url('https://fonts.googleapis.com/css?family=Open+Sans:400,800&display=swap');
+      ]]>
+    </style>
+  </defs>
   <g fill="none" fill-rule="evenodd">
     <path id="background" fill="#E62336" d="M0 0h1920v1080H0z"/>
     <text id="text" font-family="OpenSans-Regular, Open Sans" font-size="170" fill="#FFF">

--- a/src/assets/svg/LPGD_white.svg
+++ b/src/assets/svg/LPGD_white.svg
@@ -1,4 +1,11 @@
 <svg width="1920" height="1080" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style type="text/css">
+    <![CDATA[
+        @import url('https://fonts.googleapis.com/css?family=Open+Sans:400,800&display=swap');
+      ]]>
+      </style>
+  </defs>
   <g fill="none" fill-rule="evenodd">
     <path id="background" fill="#FFF" d="M0 0h1920v1080H0z"/>
     <text id="text" font-family="OpenSans-Regular, Open Sans" font-size="170" fill="#E62336">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,1 @@
 /* You can add global styles to this file, and also import other style files */
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:400,800&display=swap');
-
-body{
-  font-family: "Open Sans";
-}


### PR DESCRIPTION
Will now extract CSS @import statements from SVG CSS, request remote URL, and assemble font-face definitions for each imported font. This is then passed to saveSvgAsPng, allowing final image to honour specified fonts.